### PR TITLE
Raised to more modern FB SDK version and added 'extern' modifiers.

### DIFF
--- a/FacebookImagePicker.podspec
+++ b/FacebookImagePicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'FacebookImagePicker'
-  s.version      = '2.0.9'
+  s.version      = '2.0.10'
   s.license      = 'MIT'
   s.summary      = 'An image/photo picker for Facebook albums & photos modelled after UIImagePickerController'
   s.author       = { "Deon Botha" => "deon@oceanlabs.co" }
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   }
   s.source_files = ['FacebookImagePicker/OL*.{h,m}', 'FacebookImagePicker/UIImageView+FacebookFadeIn.{h,m}']
   s.resources = ['FacebookImagePicker/FacebookImagePicker.xcassets', 'FacebookImagePicker/*.xib']
-  s.dependency 'FBSDKCoreKit', '~> 4.8.0'
-  s.dependency 'FBSDKLoginKit', '~> 4.8.0'
+  s.dependency 'FBSDKCoreKit', '~> 4.10.0'
+  s.dependency 'FBSDKLoginKit', '~> 4.10.0'
   s.dependency 'SDWebImage', '~> 3.7.2'
 end

--- a/FacebookImagePicker.podspec
+++ b/FacebookImagePicker.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   }
   s.source_files = ['FacebookImagePicker/OL*.{h,m}', 'FacebookImagePicker/UIImageView+FacebookFadeIn.{h,m}']
   s.resources = ['FacebookImagePicker/FacebookImagePicker.xcassets', 'FacebookImagePicker/*.xib']
-  s.dependency 'FBSDKCoreKit', '~> 4.10.0'
-  s.dependency 'FBSDKLoginKit', '~> 4.10.0'
+  s.dependency 'FBSDKCoreKit', '~> 4.11.0'
+  s.dependency 'FBSDKLoginKit', '~> 4.11.0'
   s.dependency 'SDWebImage', '~> 3.7.2'
 end

--- a/FacebookImagePicker/OLFacebookImagePickerConstants.h
+++ b/FacebookImagePicker/OLFacebookImagePickerConstants.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const kOLErrorDomainFacebookImagePicker;
-const NSInteger kOLErrorCodeFacebookImagePickerBadResponse;
-const NSInteger kOLErrorCodeFacebookImagePickerNoOpenSession;
+extern NSString *const kOLErrorDomainFacebookImagePicker;
+extern const NSInteger kOLErrorCodeFacebookImagePickerBadResponse;
+extern const NSInteger kOLErrorCodeFacebookImagePickerNoOpenSession;
 


### PR DESCRIPTION
Missing `extern` modifiers cause duplicate symbol compilation errors in some cases.