### PR TITLE
[Podspec] remove version for FBSDK

### DIFF
--- a/FacebookImagePicker.podspec
+++ b/FacebookImagePicker.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   }
   s.source_files = ['FacebookImagePicker/OL*.{h,m}', 'FacebookImagePicker/UIImageView+FacebookFadeIn.{h,m}']
   s.resources = ['FacebookImagePicker/FacebookImagePicker.xcassets', 'FacebookImagePicker/*.xib']
-  s.dependency 'FBSDKCoreKit', '~> 4.13.1'
-  s.dependency 'FBSDKLoginKit', '~> 4.13.1'
+  s.dependency 'FBSDKCoreKit'
+  s.dependency 'FBSDKLoginKit'
 end

--- a/FacebookImagePicker.podspec
+++ b/FacebookImagePicker.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   }
   s.source_files = ['FacebookImagePicker/OL*.{h,m}', 'FacebookImagePicker/UIImageView+FacebookFadeIn.{h,m}']
   s.resources = ['FacebookImagePicker/FacebookImagePicker.xcassets', 'FacebookImagePicker/*.xib']
-  s.dependency 'FBSDKCoreKit', '~> 4.11.0'
-  s.dependency 'FBSDKLoginKit', '~> 4.11.0'
+  s.dependency 'FBSDKCoreKit', '~> 4.12.0'
+  s.dependency 'FBSDKLoginKit', '~> 4.12.0'
 end

--- a/FacebookImagePicker.podspec
+++ b/FacebookImagePicker.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   }
   s.source_files = ['FacebookImagePicker/OL*.{h,m}', 'FacebookImagePicker/UIImageView+FacebookFadeIn.{h,m}']
   s.resources = ['FacebookImagePicker/FacebookImagePicker.xcassets', 'FacebookImagePicker/*.xib']
-  s.dependency 'FBSDKCoreKit', '~> 4.12.0'
-  s.dependency 'FBSDKLoginKit', '~> 4.12.0'
+  s.dependency 'FBSDKCoreKit', '~> 4.13.1'
+  s.dependency 'FBSDKLoginKit', '~> 4.13.1'
 end


### PR DESCRIPTION
Hey guys! 

Great library, thank you for sharing it. We've been using it in www.getsquad.co and realized the FBSDK dependency is a version behind. It seems to run fine for our purposes on 4.12.0

Cheers!
~Mark
